### PR TITLE
Fixing an issue where cache buster is not a digit

### DIFF
--- a/angular-cache-buster.js
+++ b/angular-cache-buster.js
@@ -42,7 +42,7 @@ angular.module('ngCacheBuster', [])
 		    //Bust if the URL was on blacklist or not on whitelist
 		    if (busted) {
 			var d = new Date();
-			config.url = config.url.replace(/[?|&]cacheBuster=\d+/,'');
+			config.url = config.url.replace(/[?|&]cacheBuster=[^&]*/,'');
 			//Some url's allready have '?' attached
 			config.url+=config.url.indexOf('?') === -1 ? '?' : '&'
 			config.url += 'cacheBuster=' + window.version;


### PR DESCRIPTION
*Whats Changed?*

- We found an issue in shopland where we use ocLazyLoad to fetch an html file and it doesn't remove every part of the value in the cacheBuster query string param.

Requesting
http://path.com/to/some/template.html?cacheBuster=2015-05-01
http://path.com/to/some/template.html?cacheBuster=5.21.1-b

Became
http://path.com/to/some/template.html-05-01?cacheBuster=2015-05-01
http://path.com/to/some/template.html-1.-b?cacheBuster=5.21.1-b

This fixes that and removes any value set for cacheBuster initially so it can then append the cachebuster to the end.